### PR TITLE
fix: pointer events bug in static charts

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1462,24 +1462,24 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: d3f49c53809116a5d38da093a8aa78bf551aed09
   DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
-  EXConstants: 988aa430ca0f76b43cd46b66e7fae3287f9cc2fc
-  EXFont: f20669cb266ef48b004f1eb1f2b20db96cd1df9f
+  EXConstants: 348adb88fb0d65892f16732ec5e02e1365c31588
+  EXFont: 64e653a110eee050ad80dfcd676c4bada0a1ff92
   EXJSONUtils: 5c42959e87be238b045ef37cc5268b16a6c0ad4a
-  EXManifests: 5e8c29f36c716af768a4ea47ec05e1b89ab93091
-  Expo: c2d3edc1b1e833e26d837b03aa46d9137ca63302
-  expo-dev-client: dbc8e8a81d17a9d92e083a2856d056ba9a58984d
-  expo-dev-launcher: 3f2a78d97842a3fdc2f0116f775d8dbc32396cbd
-  expo-dev-menu: b964921baa1bda2a7ff42a407d1d7698ce215faf
-  expo-dev-menu-interface: 7ba029c9d1a82ac22b9b584c00514860b060553e
-  ExpoBlur: e832d874bd94afc0645daddbd3162ec1ce172080
-  ExpoCrypto: b6428f48599c007676dc81a9b5f72c07e62fdccc
-  ExpoFileSystem: c7488590959bf85ebc114909eb8186cbd62e3a25
-  ExpoHaptics: 28a771b630353cd6e8dcf1b1e3e693e38ad7c3c3
-  ExpoHead: 8224345e80abcf4c97b31c99805dd5a3c8d3404d
-  ExpoImage: 8cf2d51de3d03b7e984e9b0ba8f19c0c22057001
-  ExpoKeepAwake: 0f5cad99603a3268e50af9a6eb8b76d0d9ac956c
-  ExpoModulesCore: 1391529545de72f7f64ecabc7adb912306ab4d34
-  EXSplashScreen: 39244885abfb1b12765aae89edb90f8c88db6bbd
+  EXManifests: 429136cffa3ae82d1ba3b60b7243fb186615562e
+  Expo: 4cddea1bcf28057a0beb599d6959bdba1b7004cc
+  expo-dev-client: 90dd9b69d09a3a3788746df8713252f65125a18b
+  expo-dev-launcher: c539e72886bec2e7f7e2787de6d695308df413a6
+  expo-dev-menu: 4aebc7823d99f9eb63c9046366e87424d7050329
+  expo-dev-menu-interface: 44e69ddff62bbc6c5418c200e657635720b5a480
+  ExpoBlur: 3a9548a738624968836926f4aa1e18fa22155640
+  ExpoCrypto: 9be8806e896380cb18e5d3d2c13a89ce2f36946a
+  ExpoFileSystem: 6fd0602259f89b3b2c243393698bcc9f3e40d6a2
+  ExpoHaptics: c91902e436f3fb0e07aa19acc118018089fa90de
+  ExpoHead: dae7e0e9f8b2e65f8fb56f7a7fe1014a1eacc6ab
+  ExpoImage: a70db90f39a7af98930cef91c84e877b1131f3dd
+  ExpoKeepAwake: 3b8cf8533b9212500565a1e41fb080fc5af29918
+  ExpoModulesCore: 50f6f101bae3b22d08a70e47dc5103309ee1c657
+  EXSplashScreen: bfc61068a9659d15f9c28e6b7fab96c0a3b40e11
   EXUpdatesInterface: 3e444e2093e25b7ca0999a7d8c16e8392dee70c3
   FBLazyVector: 84f6edbe225f38aebd9deaf1540a4160b1f087d7
   FBReactNativeSpec: d0086a479be91c44ce4687a962956a352d2dc697
@@ -1491,59 +1491,59 @@ SPEC CHECKSUMS:
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   libvmaf: 27f523f1e63c694d14d534cd0fddd2fab0ae8711
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
-  RCT-Folly: 7169b2b1c44399c76a47b5deaaba715eeeb476c0
+  RCT-Folly: cd21f1661364f975ae76b3308167ad66b09f53f5
   RCTRequired: ab7f915c15569f04a49669e573e6e319a53f9faa
   RCTTypeSafety: 63b97ced7b766865057e7154db0e81ce4ee6cf1e
   React: 1c87497e50fa40ba9c54e5ea5e53483a0f8eecc0
   React-callinvoker: e3a52a9a93e3eb004d7282c26a4fb27003273fe6
-  React-Codegen: 50c0f8f073e71b929b057b68bf31be604f1dccc8
-  React-Core: d0ecde72894b792cb8922efaa0990199cbe85169
-  React-CoreModules: 2ff1684dd517f0c441495d90a704d499f05e9d0a
-  React-cxxreact: d9be2fac926741052395da0a6d0bab8d71e2f297
+  React-Codegen: accd8617d26d9e8192f2105e2b715f346bbd6888
+  React-Core: e063354ccbed01b836af1e6e94b5cb8319097104
+  React-CoreModules: db63015ed3e85382f6d8ec7f78b5136cfb345c18
+  React-cxxreact: 7e569c1f7e4dda58ba17df36450c6d98df407b5b
   React-debug: 4678e73a37cb501d784e99ff0f219b4940362a3b
-  React-Fabric: 460ee9d4b8b9de3382504a711430bfead1d5be1e
-  React-FabricImage: d0a0631bc8ad9143f42bfccf9d3d533a144cc3d6
-  React-graphics: f0d5040263a9649e2a70ebe27b3120c49411afef
-  React-hermes: b9ac2f7b0c1eeb206eb883583cab7a973d570a6e
-  React-ImageManager: 6c4bf9d5ed363ead7b5aaf820a3feab221b7063e
-  React-jserrorhandler: 6e7a7e187583e14dc7a0053a2bdd66c252ea3b21
-  React-jsi: 380cd24dd81a705dd042c18989fb10b07182210c
-  React-jsiexecutor: 8ed7a18b9f119440efdcd424c8257dc7e18067e2
+  React-Fabric: a6a9148a530e4b5e984f5f3373b07ee0a2e41f45
+  React-FabricImage: 701972b5524a7a6a02710b55f0f6a82e94bd7da8
+  React-graphics: 46697b8481d17ead6e346f2cbdeee443eff3fd18
+  React-hermes: a29dacf053e80ebe20b680e30afe26580521e0c9
+  React-ImageManager: 9ae8207447796390d7b78beffd7aec8dc28311c4
+  React-jserrorhandler: e53f2eee7b67787ac8bfb6a709ac4eecdb57c2e9
+  React-jsi: 6db2f81ad41fc50394a70af6e38dd23ac483ff79
+  React-jsiexecutor: 951f2809bea7cab011dd1bbe06c631c75df4f673
   React-jsinspector: 9ac353eccf6ab54d1e0a33862ba91221d1e88460
-  React-logger: 0a57b68dd2aec7ff738195f081f0520724b35dab
-  React-Mapbuffer: 63913773ed7f96b814a2521e13e6d010282096ad
-  react-native-animateable-text: 79b31ec28f4ed14dab76b304eb74a24eeb2fa9c0
-  react-native-safe-area-context: 0ee144a6170530ccc37a0fd9388e28d06f516a89
-  react-native-skia: 61a8a1c161ebf4e677b2d39af880c997d8847313
+  React-logger: 5295f5eac9d7624fe9a33a473442d8f4c1074197
+  React-Mapbuffer: f7ba4d5459e546d741791a55664388e97b31df7c
+  react-native-animateable-text: 0019b1018044c01069c7408bfbc149ff1260af41
+  react-native-safe-area-context: bf9d9d58f0f6726d4a6257088044c2595017579d
+  react-native-skia: d6c5b2af167f01d63f6bd861f0283d8ac1a9752a
   React-nativeconfig: d7af5bae6da70fa15ce44f045621cf99ed24087c
-  React-NativeModulesApple: 0123905d5699853ac68519607555a9a4f5c7b3ac
+  React-NativeModulesApple: 7a561c2792b0a2b74aff6c58d2554dcf824372aa
   React-perflogger: 8a1e1af5733004bdd91258dcefbde21e0d1faccd
   React-RCTActionSheet: 64bbff3a3963664c2d0146f870fe8e0264aee4c4
-  React-RCTAnimation: b698168a7269265a4694727196484342d695f0c1
-  React-RCTAppDelegate: dcd8e955116eb1d1908dfaf08b4c970812e6a1e6
-  React-RCTBlob: 47f8c3b2b4b7fa2c5f19c43f0b7f77f57fb9d953
-  React-RCTFabric: 6067a32d683d0c2b84d444548bc15a263c64abed
-  React-RCTImage: ac0e77a44c290b20db783649b2b9cddc93e3eb99
-  React-RCTLinking: e626fd2900913fe5d25922ea1be394b7aafa09c9
-  React-RCTNetwork: d3114bce3977dafe8bd06421b29812f5a8527ba0
-  React-RCTSettings: a53511f90d8df637a1a11ac729179a4d2f734481
-  React-RCTText: f0176f5f5952f9a4a2c7354f5ae71f7c420aaf34
-  React-RCTVibration: 8160223c6eda5b187079fec204f80eca8b8f3177
-  React-rendererdebug: ed286b4da8648c27d6ed3ae1410d4b21ba890d5a
+  React-RCTAnimation: 548fdbd189275f721a4f3098da847a84e3e3339f
+  React-RCTAppDelegate: 7d6c7ca4a9d94c889533ad6730782f176ff4b43a
+  React-RCTBlob: 7bf2d87c667d5a570212d921583dca5e1156395c
+  React-RCTFabric: d3eee95226b91877334fefbbd4d48122f114506b
+  React-RCTImage: 8ad4a0f9e728ff81a229446a6a8de8657c133cc6
+  React-RCTLinking: 12c1070797c9242b8ca2d171fc43588de47e442d
+  React-RCTNetwork: 1a59d000d0053f56f405d52521ae9df1b6108aa3
+  React-RCTSettings: a3b91c385e2f3bc7aa2bae75b2f60c6fd0c9052e
+  React-RCTText: 78330d21c9d14d680f31a3a3866436b978a66a8c
+  React-RCTVibration: 632344d1fdb7f1d568d1c6715f2dfe270fff6e88
+  React-rendererdebug: 740d4bbbbea219809a58cde58c8af0e39c787831
   React-rncore: 43f133b89ac10c4b6ab43702a541dee1c292a3bf
   React-runtimeexecutor: e6ab6bb083dbdbdd489cff426ed0bce0652e6edf
-  React-runtimescheduler: ed48e5faac6751e66ee1261c4bd01643b436f112
-  React-utils: 6e5ad394416482ae21831050928ae27348f83487
-  ReactCommon: 840a955d37b7f3358554d819446bffcf624b2522
-  RNGestureHandler: deda62b8339496ba721a45e0f3e2d7a319932cee
-  RNReanimated: 3850671fd0c67051ea8e1e648e8c3e86bf3a28eb
-  RNScreens: b582cb834dc4133307562e930e8fa914b8c04ef2
+  React-runtimescheduler: ceaeeb19e75912958625f72883d240640e8f40da
+  React-utils: 8439db27c3745f6de9d67eb61f5600c8d624274c
+  ReactCommon: cc18bd33c0fab03c67620da6a602dcc1704e66b4
+  RNGestureHandler: 2a76de24abfbdfdc7a7a5fcb4b5e57563ada065e
+  RNReanimated: dec55644357451e94ab91e0bf16b350b869c9cd9
+  RNScreens: 8d1521c6e375a79dbd4525efaf21704cc64ac0cf
   SDWebImage: 750adf017a315a280c60fde706ab1e552a3ae4e9
   SDWebImageAVIFCoder: 8348fef6d0ec69e129c66c9fe4d74fbfbf366112
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: af09429398d99d524cae2fe00f6f0f6e491ed102
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  Yoga: 64cd2a583ead952b0315d5135bf39e053ae9be70
+  Yoga: 1b901a6d6eeba4e8a2e8f308f708691cdb5db312
 
 PODFILE CHECKSUM: 0bd31d4d3637422db705fe5355565acd8e715825
 

--- a/src/components/LineChart/StaticLineChart.tsx
+++ b/src/components/LineChart/StaticLineChart.tsx
@@ -44,7 +44,7 @@ export const StaticLineChart: React.FC<LineChartProps<true>> = ({
           <TopAxisLabel value={data.maxValue} />
         </AxisLabelContainer>
       )}
-      <View style={styles.container} onLayout={onLayout}>
+      <View style={styles.container} onLayout={onLayout} pointerEvents="none">
         <Canvas style={{ height, width }}>
           <Path style="stroke" path={path} strokeWidth={strokeWidth} color="transparent">
             {PathFill && PathFill({ width, height, strokeWidth })}

--- a/src/components/MultiLineChart/StaticMultiLineChart.tsx
+++ b/src/components/MultiLineChart/StaticMultiLineChart.tsx
@@ -26,7 +26,7 @@ export const StaticMultiLineChart = <Data extends Record<string, [number, number
 
   return (
     <View style={[styles.root, viewProps.style]} {...viewProps}>
-      <View style={styles.container} onLayout={onLayout}>
+      <View style={styles.container} onLayout={onLayout} pointerEvents="none">
         <Canvas style={{ height, width }}>
           {!layoutComputed
             ? null


### PR DESCRIPTION
## Description

Sets `pointerEvents` to `none` on static chart canvas containers so Skia-drawn lines no longer intercept taps; buttons and pressables receive touches.

## Motivation and Context

In newer versions of Skia, components seem to be intercepting taps, causing issues with touchable elements (e.g., `Pressable`) not having their onPress's register.

## How Has This Been Tested?

Manually on the [porfoli](https://porfoli.com) app.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have followed the guidelines in the README.md file.
- [x] I have updated the documentation as necessary.
- [x] My changes generate no new warnings.
